### PR TITLE
Support threads count in tfjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
         "webpack-cli": "^3.3.12"
     },
     "dependencies": {
-        "@tensorflow/tfjs": "3.6.0",
-        "@tensorflow/tfjs-backend-wasm": "3.6.0",
+        "@tensorflow/tfjs": "^3.10.0",
+        "@tensorflow/tfjs-backend-wasm": "^3.10.0",
         "cross-var": "^1.1.0",
         "flatbuffers": "^1.12.0",
         "fsevents": "2.3.2",

--- a/sample-configs/run_config_mediapipe_facemesh.json
+++ b/sample-configs/run_config_mediapipe_facemesh.json
@@ -29,7 +29,7 @@
             "pack": true
         },
         "wasm": {
-            "threading": true,
+            "numThreads": 0,
             "simd": true
         }
     }

--- a/sample-configs/run_config_softmax_test.json
+++ b/sample-configs/run_config_softmax_test.json
@@ -26,7 +26,7 @@
             "pack": true
         },
         "wasm": {
-            "threading": true,
+            "numThreads": 0,
             "simd": true
         }
     }

--- a/src/tfjs-benchmark.ts
+++ b/src/tfjs-benchmark.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import * as tf from '@tensorflow/tfjs';
-import '@tensorflow/tfjs-backend-wasm';
+import {setThreadsCount} from '@tensorflow/tfjs-backend-wasm';
 import {Benchmark, BenchmarkBasePath} from './benchmark';
 
 type TensorflowModelType = tf.GraphModel|tf.LayersModel;
@@ -32,8 +32,12 @@ export class TensorFlowBenchmark implements Benchmark {
     console.log(`Tfjs pack mode enabled: ${tf.env().getBool('WEBGL_PACK')}`);
 
     console.log(`Setting the backend to ${backend}`);
-    if (config.tfjs.wasm.threading !== undefined) {
-        tf.env().set('WASM_HAS_MULTITHREAD_SUPPORT', config.tfjs.wasm.threading);
+    if (config.tfjs.wasm.threading !== undefined ||
+        (config.tfjs.wasm.numThreads !== undefined && config.tfjs.wasm.numThreads !== 1)) {
+        tf.env().set('WASM_HAS_MULTITHREAD_SUPPORT', config.tfjs.wasm.threading !== undefined ? config.tfjs.wasm.threading : true);
+        if (config.tfjs.wasm.numThreads !== undefined && config.tfjs.wasm.numThreads > 1) {
+            setThreadsCount(config.tfjs.wasm.numThreads);
+        }
     }
     if (config.tfjs.wasm.simd !== undefined) {
         tf.env().set('WASM_HAS_SIMD_SUPPORT', config.tfjs.wasm.simd);


### PR DESCRIPTION
It supports config.tfjs.wasm.numThreads to adjust the number of threads in tfjs. config.tfjs.wasm.threading is also supported for backward compatibility.